### PR TITLE
Bump firmware version to v1.1.2

### DIFF
--- a/SOFTWARE/CMakeLists.txt
+++ b/SOFTWARE/CMakeLists.txt
@@ -34,7 +34,7 @@ set(PICO_SDK_FETCH_FROM_GIT ON)
 set(PICO_SDK_FETCH_SDK_VERSION 2.1.1)
 include(pico_sdk_import.cmake)
 
-project(klystron VERSION 1.1.1 LANGUAGES C CXX)
+project(klystron VERSION 1.1.2 LANGUAGES C CXX)
 
 # Initialise the Raspberry Pi Pico SDK
 pico_sdk_init()


### PR DESCRIPTION
### Motivation
- Prepare the firmware for release by updating the project version to `1.1.2` so build metadata and `FW_VERSION_*` values reflect the new release.

### Description
- Changed `project(klystron VERSION 1.1.1 LANGUAGES C CXX)` to `project(klystron VERSION 1.1.2 LANGUAGES C CXX)` in `SOFTWARE/CMakeLists.txt` to increment the firmware version.

### Testing
- Verified the update by running `rg -n "project\(klystron VERSION" SOFTWARE/CMakeLists.txt` and inspecting the `git diff`/file contents, confirming the line now reads `1.1.2` (commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c1c3d5c88320b6a209d01da5050f)