### PR TITLE
Refactor fire input handling with hardware timer-based debounce

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,9 @@ This matrix must be fully tested and passed before submitting changes. `N` refer
 | **TVG Lights** | Normal Operation | TVG patterns run as documented. Remainder LEDs are off. |
 | **TVG Fire Timing** | Wand lights attached, ear tap (100 ms pulse) | Weapon mode changes. Nothing fires, and the wand stays in step with the pack. |
 | | Wand lights attached, quick fire tap (180 ms pulse) | Short burst of firing. Mode does **not** change. |
-| | Standalone, quick tap of the fire switch | Weapon mode changes (allow one tap after power-up for the firmware to settle on the standalone window). |
-| | Standalone, press held past ~300 ms | Fires; mode does not change. |
+| | Wand lights attached, fire held | Fires continuously, starting ~140 ms in. Mode does not change. |
+| | Fire pulse of any length | Exactly one outcome — never both a mode change and a shot, never neither. |
+| | Repeat the above with lots of LEDs lit (ADJ1 = 40, party or Afterlife animations) | Identical results. The threshold is timed off the hardware clock, so LED load must not move it. |
 | | Any non-TVG pack type | Firing starts on the debounced press; taps never change mode. |
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,11 @@ This matrix must be fully tested and passed before submitting changes. `N` refer
 | **Powercell** | Normal Operation | Powercell light scrolls from bottom to top endlessly. Does not stall. |
 | **Future Light** | Firing the wand | N-Filter light activates only during firing states. |
 | **TVG Lights** | Normal Operation | TVG patterns run as documented. Remainder LEDs are off. |
+| **TVG Fire Timing** | Wand lights attached, ear tap (100 ms pulse) | Weapon mode changes. Nothing fires, and the wand stays in step with the pack. |
+| | Wand lights attached, quick fire tap (180 ms pulse) | Short burst of firing. Mode does **not** change. |
+| | Standalone, quick tap of the fire switch | Weapon mode changes (allow one tap after power-up for the firmware to settle on the standalone window). |
+| | Standalone, press held past ~300 ms | Fires; mode does not change. |
+| | Any non-TVG pack type | Firing starts on the debounced press; taps never change mode. |
 
 
 ## 3. Control References

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ This matrix must be fully tested and passed before submitting changes. `N` refer
 | **TVG Lights** | Normal Operation | TVG patterns run as documented. Remainder LEDs are off. |
 | **TVG Fire Timing** | Wand lights attached, ear tap (100 ms pulse) | Weapon mode changes. Nothing fires, and the wand stays in step with the pack. |
 | | Wand lights attached, quick fire tap (180 ms pulse) | Short burst of firing. Mode does **not** change. |
-| | Wand lights attached, fire held | Fires continuously, starting ~140 ms in. Mode does not change. |
+| | Wand lights attached, fire held | Fires continuously, starting ~135 ms in. Mode does not change. |
 | | Fire pulse of any length | Exactly one outcome — never both a mode change and a shot, never neither. |
 | | Repeat the above with lots of LEDs lit (ADJ1 = 40, party or Afterlife animations) | Identical results. The threshold is timed off the hardware clock, so LED load must not move it. |
 | | Any non-TVG pack type | Firing starts on the debounced press; taps never change mode. |

--- a/HARDWARE/README.md
+++ b/HARDWARE/README.md
@@ -114,7 +114,12 @@ Only four user switches are needed to control the sounds:
 2. **Fire** –
    - Hold for continuous firing (Proton Stream)
    - Hold and release for single shots (Boson Dart in TVG modes)
-   - Tap quickly to cycle TVG weapons
+   - Tap quickly to cycle TVG weapons. A tap counts as a mode change only if it
+     ends inside the tap window; hold past it and the pack fires instead. The
+     window is 140 ms when a wand lights board drives the fire input and 300 ms
+     when a plain switch does, which the firmware detects for itself. Non‑TVG
+     pack types have no weapon modes and fire as soon as the contact is
+     debounced.
 3. **Song** – toggling this input starts the Ghostbusters theme song. It works
    even after a power‑down sound, as long as battery power remains.
 4. **Vent** – plays the vent sound. In TVG pack sounds, a “dry vent” is heard if

--- a/HARDWARE/README.md
+++ b/HARDWARE/README.md
@@ -114,10 +114,10 @@ Only four user switches are needed to control the sounds:
 2. **Fire** –
    - Hold for continuous firing (Proton Stream)
    - Hold and release for single shots (Boson Dart in TVG modes)
-   - Tap quickly to cycle TVG weapons. A tap counts as a mode change only if it
-     ends inside the tap window; hold past it and the pack fires instead. The
-     window is 140 ms when a wand lights board drives the fire input and 300 ms
-     when a plain switch does, which the firmware detects for itself. Non‑TVG
+   - Tap quickly to cycle TVG weapons. A tap counts as a mode change only if the
+     pulse ends within 140 ms; still held past that and the pack fires instead.
+     The Wand Lights board makes this exact by emitting a fixed 100 ms pulse for
+     the ear button and stretching the fire button to at least 180 ms. Non‑TVG
      pack types have no weapon modes and fire as soon as the contact is
      debounced.
 3. **Song** – toggling this input starts the Ghostbusters theme song. It works

--- a/HARDWARE/README.md
+++ b/HARDWARE/README.md
@@ -115,7 +115,7 @@ Only four user switches are needed to control the sounds:
    - Hold for continuous firing (Proton Stream)
    - Hold and release for single shots (Boson Dart in TVG modes)
    - Tap quickly to cycle TVG weapons. A tap counts as a mode change only if the
-     pulse ends within 140 ms; still held past that and the pack fires instead.
+     pulse ends within 135 ms; still held past that and the pack fires instead.
      The Wand Lights board makes this exact by emitting a fixed 100 ms pulse for
      the ear button and stretching the fire button to at least 180 ms. Non‑TVG
      pack types have no weapon modes and fire as soon as the contact is

--- a/README.md
+++ b/README.md
@@ -166,6 +166,38 @@ appropriate value with ADJ1.
 ### TVG Lights
 When the pack is set to a TVG mode (via `PackSel0`/`PackSel1` DIP switches), the fire button can be tapped (when not firing) to cycle through different weapon modes. Each mode has a unique color for the cyclotron and powercell, as defined in the firmware. These modes include the Proton Stream, Slime Blower, Stasis Stream, and more. The TVG lights respect the `N` setting from the ADJ1 potentiometer, meaning only the selected number of LEDs will be active.
 
+#### Fire button timing in TVG modes
+In a TVG mode a press on the fire input is ambiguous until it either ends or
+outlasts the **tap window**:
+
+- The pulse **ends inside** the window → mode change; nothing fires.
+- The pulse is **still active at the end** of the window → firing starts right
+  then, and no mode change happens.
+
+The two outcomes are mutually exclusive, so a single press can never both fire
+and change mode. In every non-TVG pack type there are no weapon modes to cycle,
+so firing starts as soon as the fire contact is debounced (about 12 ms) and the
+window is not used at all.
+
+The window itself depends on what is driving the fire input, which the firmware
+works out on its own — there is no setting to change:
+
+| Fire input driven by | Tap window | Why |
+|----------------------|-----------|-----|
+| A wand lights board | 140 ms | The wand stretches its own fire button to at least 180 ms and emits a fixed 100 ms pulse for the ear button, so 140 ms cleanly separates the two. |
+| A plain switch (standalone) | 300 ms | Nobody can tap a bare button under 140 ms reliably. |
+
+A wand lights board never passes the raw button through, so it can only ever
+produce a pulse of roughly 100 ms or one of 180 ms and up. The firmware watches
+the width of completed fire pulses in TVG modes: one that lands near 100 ms can
+only have come from a wand's ear button, and one that lands between about
+128 ms and 164 ms is a width no wand can generate, so it must be a bare switch.
+Anything else is ambiguous and is ignored. A wand is assumed until proven
+otherwise, and once the link has settled it takes two disagreeing presses to
+change the verdict, so an unusually timed press cannot move the window out from
+under you. In standalone use expect the first tap after power-up to fire before
+the firmware settles on the longer window.
+
 ## Building with Visual Studio Code
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/) and the

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ When the pack is set to a TVG mode (via `PackSel0`/`PackSel1` DIP switches), the
 
 #### Fire button timing in TVG modes
 In a TVG mode a press on the fire input is ambiguous until it either ends or
-outlasts the **140 ms tap window**:
+outlasts the **135 ms tap window**:
 
 - The pulse **ends inside** the window → mode change; nothing fires.
 - The pulse is **still active at the end** of the window → firing starts right
@@ -179,11 +179,16 @@ never do nothing. Because of that, firing in a TVG mode is always held off for
 the length of the window — there is no way to know which request a press is
 until it resolves.
 
-The 140 ms figure comes from the Wand Lights board, which conditions the line
-rather than passing the button through: the ear button emits a fixed 100 ms
-pulse and the fire button is stretched to at least 180 ms, so 140 ms sits
-between them with 40 ms of margin either side. Wired directly to a switch, the
-same threshold applies and the tap has to be made by hand.
+The figure comes from the Wand Lights board, which conditions the line rather
+than passing the button through: the ear button emits a fixed 100 ms pulse and
+the fire button is stretched to at least 180 ms. Sweeping the threshold across
+poll intervals of 4 to 6 ms and every phase alignment of the pulse against the
+poll grid, a 100 ms pulse stays a mode change from 97 ms upwards and a 180 ms
+pulse still fires up to 173 ms; 135 ms is the midpoint of that band, so the
+margin is an equal 38 ms on each side. Rebuild with
+`-DFIRE_TAP_WINDOW_MS=<value>` to re-sweep it against real hardware. Wired
+directly to a switch the same threshold applies, and the tap has to be made by
+hand.
 
 In every non-TVG pack type there are no weapon modes to cycle, so firing starts
 as soon as the fire contact is debounced (about 12 ms) and the window is not
@@ -194,8 +199,8 @@ passes through the pack timer ISR. The ISR is armed with a positive delay,
 which the Pico SDK defines as the gap between one callback ending and the next
 starting, and the same callback drives the LED output — so the interval between
 two polls is 4 ms plus however long the previous pass took, and it moves with
-LED load. Timestamping keeps the threshold at a true 140 ms; the poll rate only
-sets the resolution, so the boundary lands within one poll of 140 ms no matter
+LED load. Timestamping keeps the threshold at a true 135 ms; the poll rate only
+sets the resolution, so the boundary lands within one poll of 135 ms no matter
 what the animations are doing.
 
 ## Building with Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -168,35 +168,35 @@ When the pack is set to a TVG mode (via `PackSel0`/`PackSel1` DIP switches), the
 
 #### Fire button timing in TVG modes
 In a TVG mode a press on the fire input is ambiguous until it either ends or
-outlasts the **tap window**:
+outlasts the **140 ms tap window**:
 
 - The pulse **ends inside** the window → mode change; nothing fires.
 - The pulse is **still active at the end** of the window → firing starts right
   then, and no mode change happens.
 
-The two outcomes are mutually exclusive, so a single press can never both fire
-and change mode. In every non-TVG pack type there are no weapon modes to cycle,
-so firing starts as soon as the fire contact is debounced (about 12 ms) and the
-window is not used at all.
+The two outcomes are exactly complementary: a press can never do both, and
+never do nothing. Because of that, firing in a TVG mode is always held off for
+the length of the window — there is no way to know which request a press is
+until it resolves.
 
-The window itself depends on what is driving the fire input, which the firmware
-works out on its own — there is no setting to change:
+The 140 ms figure comes from the Wand Lights board, which conditions the line
+rather than passing the button through: the ear button emits a fixed 100 ms
+pulse and the fire button is stretched to at least 180 ms, so 140 ms sits
+between them with 40 ms of margin either side. Wired directly to a switch, the
+same threshold applies and the tap has to be made by hand.
 
-| Fire input driven by | Tap window | Why |
-|----------------------|-----------|-----|
-| A wand lights board | 140 ms | The wand stretches its own fire button to at least 180 ms and emits a fixed 100 ms pulse for the ear button, so 140 ms cleanly separates the two. |
-| A plain switch (standalone) | 300 ms | Nobody can tap a bare button under 140 ms reliably. |
+In every non-TVG pack type there are no weapon modes to cycle, so firing starts
+as soon as the fire contact is debounced (about 12 ms) and the window is not
+used at all.
 
-A wand lights board never passes the raw button through, so it can only ever
-produce a pulse of roughly 100 ms or one of 180 ms and up. The firmware watches
-the width of completed fire pulses in TVG modes: one that lands near 100 ms can
-only have come from a wand's ear button, and one that lands between about
-128 ms and 164 ms is a width no wand can generate, so it must be a bare switch.
-Anything else is ambiguous and is ignored. A wand is assumed until proven
-otherwise, and once the link has settled it takes two disagreeing presses to
-change the verdict, so an unusually timed press cannot move the window out from
-under you. In standalone use expect the first tap after power-up to fire before
-the firmware settles on the longer window.
+Widths are measured against the hardware microsecond timer, not by counting
+passes through the pack timer ISR. The ISR is armed with a positive delay,
+which the Pico SDK defines as the gap between one callback ending and the next
+starting, and the same callback drives the LED output — so the interval between
+two polls is 4 ms plus however long the previous pass took, and it moves with
+LED load. Timestamping keeps the threshold at a true 140 ms; the poll rate only
+sets the resolution, so the boundary lands within one poll of 140 ms no matter
+what the animations are doing.
 
 ## Building with Visual Studio Code
 

--- a/SOFTWARE/CMakeLists.txt
+++ b/SOFTWARE/CMakeLists.txt
@@ -34,7 +34,7 @@ set(PICO_SDK_FETCH_FROM_GIT ON)
 set(PICO_SDK_FETCH_SDK_VERSION 2.1.1)
 include(pico_sdk_import.cmake)
 
-project(klystron VERSION 1.1.2 LANGUAGES C CXX)
+project(klystron VERSION 1.1.3 LANGUAGES C CXX)
 
 # Initialise the Raspberry Pi Pico SDK
 pico_sdk_init()

--- a/SOFTWARE/klystron.cpp
+++ b/SOFTWARE/klystron.cpp
@@ -76,6 +76,14 @@ bool pack_timer_isr(struct repeating_timer *t) {
 
 /**
  * @brief Initializes the repeating timer used for pack updates.
+ * @note The delay is positive, which the SDK defines as the gap between one
+ *       callback ending and the next starting rather than a fixed period. The
+ *       callback also drives the LED output, and FastLED caps the RP2040
+ *       clockless driver at 400 Hz with a busy-wait, so the real interval
+ *       between two passes is `pack_isr_interval_ms` plus however long the
+ *       previous pass took. Anything that has to measure a real duration must
+ *       therefore read the hardware timer rather than count callbacks - see
+ *       the FIRE input timing in `klystron_IO_support.cpp`.
  */
 void init_pack_timer(void) {
     static struct repeating_timer timer;

--- a/SOFTWARE/klystron_IO_support.cpp
+++ b/SOFTWARE/klystron_IO_support.cpp
@@ -132,6 +132,174 @@ void check_dip_switches_isr(void) {
     }
 }
 
+// === FIRE input timing ===
+//
+// Everything below is counted in ISR ticks of PACK_ISR_INTERVAL_MS, so a
+// measured pulse width is only accurate to within one tick either way.
+
+/** @brief Stable samples required before a fire edge is accepted (12 ms). */
+static const uint16_t FIRE_DEBOUNCE_TICKS = PACK_ISR_TICKS(12);
+/** @brief Shortest pulse accepted as a deliberate tap (20 ms). */
+static const uint16_t FIRE_TAP_MIN_TICKS = PACK_ISR_TICKS(20);
+/** @brief Tap window when a wand lights board drives the fire line. */
+static const uint16_t FIRE_TAP_WINDOW_WAND_TICKS = PACK_ISR_TICKS(140);
+/** @brief Tap window when a plain switch drives the fire line. */
+static const uint16_t FIRE_TAP_WINDOW_STANDALONE_TICKS = PACK_ISR_TICKS(300);
+
+// --- Wand lights link detection ---
+//
+// There is no dedicated wand-present input, so the link is identified from
+// the shape of the pulses arriving on the fire line. A wand lights board
+// never passes the raw button through:
+//
+//   * a press of the wand's FIRE button is stretched to at least 180 ms
+//   * a press of the wand's EAR button emits a fixed 100 ms pulse
+//
+// So a wand can only ever produce a pulse of about 100 ms or one of 180 ms
+// and up; nothing in between, and nothing shorter. A switch wired straight to
+// the FIRE input has no such shaping and lands wherever the user's thumb puts
+// it - typically well above 140 ms, which is exactly why a 140 ms window is
+// unusable standalone.
+//
+// A completed pulse is therefore classed as:
+//
+//   76..124 ms  only the wand's ear pulse lands here -> wand attached
+//   128..164 ms a wand cannot generate this width    -> standalone
+//   otherwise   ambiguous, leaves the link state alone
+//
+// Until there is evidence either way a wand is assumed, because mistaking a
+// wand's 180 ms fire pulse for a mode change desynchronises the pack from the
+// wand, which is far worse than a standalone tap firing once before the link
+// is identified.
+
+/** @brief Pulse width range matching the wand's fixed ear pulse. */
+static const uint16_t FIRE_WAND_EAR_MIN_TICKS = PACK_ISR_TICKS(76);
+static const uint16_t FIRE_WAND_EAR_MAX_TICKS = PACK_ISR_TICKS(124);
+/** @brief Pulse width range no wand lights board can produce. */
+static const uint16_t FIRE_WAND_GAP_MIN_TICKS = PACK_ISR_TICKS(128);
+static const uint16_t FIRE_WAND_GAP_MAX_TICKS = PACK_ISR_TICKS(164);
+/** @brief Contrary pulses needed to overturn an established link state. */
+static const uint8_t FIRE_LINK_FLIP_COUNT = 2;
+
+/** @brief What is currently believed to be driving the fire line. */
+static volatile FireLinkState fire_link = FIRE_LINK_UNKNOWN;
+
+/**
+ * @brief Feed a completed fire pulse width into the link detector.
+ * @param width_ticks Measured width of the pulse in ISR ticks.
+ */
+static void classify_fire_pulse(uint16_t width_ticks) {
+    static uint8_t contrary_pulses = 0;
+    FireLinkState evidence = FIRE_LINK_UNKNOWN;
+
+    if ((width_ticks >= FIRE_WAND_EAR_MIN_TICKS) &&
+        (width_ticks <= FIRE_WAND_EAR_MAX_TICKS)) {
+        evidence = FIRE_LINK_WAND;
+    } else if ((width_ticks >= FIRE_WAND_GAP_MIN_TICKS) &&
+               (width_ticks <= FIRE_WAND_GAP_MAX_TICKS)) {
+        evidence = FIRE_LINK_STANDALONE;
+    }
+
+    if (evidence == FIRE_LINK_UNKNOWN) {
+        return;
+    }
+    if (fire_link == FIRE_LINK_UNKNOWN) {
+        fire_link = evidence;
+        contrary_pulses = 0;
+    } else if (evidence == fire_link) {
+        contrary_pulses = 0;
+    } else if (++contrary_pulses >= FIRE_LINK_FLIP_COUNT) {
+        // Only overturn a settled link after repeated disagreement so a single
+        // oddly timed press cannot flip the timing out from under the user.
+        fire_link = evidence;
+        contrary_pulses = 0;
+    }
+}
+
+/** @brief Tap window currently in force, in ISR ticks. */
+static uint16_t fire_tap_window_ticks(void) {
+    return (fire_link == FIRE_LINK_STANDALONE)
+               ? FIRE_TAP_WINDOW_STANDALONE_TICKS
+               : FIRE_TAP_WINDOW_WAND_TICKS;
+}
+
+/**
+ * @brief ISR-based debounce and classification of the FIRE input.
+ * @details In TVG modes a press is ambiguous until the tap window has passed:
+ *          a pulse that ends inside the window is a mode change request and a
+ *          pulse still active at the end of it is a fire request. Firing is
+ *          therefore held off until the window expires, and the tap event is
+ *          only raised once the release has been debounced. Every other pack
+ *          type has no mode cycling, so firing starts as soon as the contact
+ *          is debounced.
+ */
+static void check_fire_switch_isr(void) {
+    static bool fire_stable_pressed = false;
+    static bool fire_last_sample = false;
+    static uint16_t fire_stable_cnt = 0;
+    static uint16_t fire_press_ticks = 0;
+
+    const bool tvg = config_pack_is_tvg();
+    const uint16_t tap_window = fire_tap_window_ticks();
+
+    bool fire_sample_pressed = (gpio_get(GPI_FIRE) == 0);
+    if (fire_sample_pressed != fire_last_sample) {
+        fire_last_sample = fire_sample_pressed;
+        fire_stable_cnt = 0;
+    } else if (fire_stable_cnt < FIRE_DEBOUNCE_TICKS) {
+        fire_stable_cnt++;
+    }
+
+    // Count every sample the contact has been seen closed for. The counter is
+    // frozen the moment the raw input opens, so a width can never creep past
+    // the tap window while the release is still being debounced. That keeps
+    // "released inside the window" and "still held at the end of it" mutually
+    // exclusive.
+    if (fire_stable_pressed && fire_sample_pressed &&
+        (fire_press_ticks < UINT16_MAX)) {
+        fire_press_ticks++;
+    }
+
+    if ((fire_stable_cnt >= FIRE_DEBOUNCE_TICKS) &&
+        (fire_stable_pressed != fire_sample_pressed)) {
+        fire_stable_pressed = fire_sample_pressed;
+        if (fire_stable_pressed) {
+            // Account for the samples that went into accepting the press:
+            // this one plus the FIRE_DEBOUNCE_TICKS before it.
+            fire_press_ticks = FIRE_DEBOUNCE_TICKS + 1;
+            user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_TAP_MASK;
+            user_switches |= USER_SWITCH_FIRE_MASK;
+        } else {
+            if (tvg) {
+                if ((fire_press_ticks >= FIRE_TAP_MIN_TICKS) &&
+                    (fire_press_ticks <= tap_window)) {
+                    user_switch_flags |= USER_SWITCH_FLAG_FIRE_TAP_MASK;
+                }
+                // Only TVG presses are useful evidence: they are the ones made
+                // while trying to change mode. Short bursts of firing in the
+                // other pack types would just muddy the classification.
+                classify_fire_pulse(fire_press_ticks);
+            }
+            // Drop the press straight away. Leaving it set would let fire_sw()
+            // read true for the rest of the release debounce and turn a mode
+            // change into a burst of firing.
+            user_switches &= ~USER_SWITCH_FIRE_MASK;
+            fire_press_ticks = 0;
+        }
+    }
+
+    // Re-evaluated every tick rather than latched on an edge so that the main
+    // loop clearing flags, or the pack type changing mid-press, cannot leave
+    // the gate stuck in the wrong position.
+    if (!tvg) {
+        user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_MASK;
+    } else if (fire_stable_pressed && (fire_press_ticks <= tap_window)) {
+        user_switch_flags |= USER_SWITCH_FLAG_FIRE_HELD_MASK;
+    } else {
+        user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_HELD_MASK;
+    }
+}
+
 /**
  * @brief ISR-based function to read and debounce the user-facing switches.
  * @details Called by the repeating timer ISR. It debounces the main switches
@@ -142,24 +310,18 @@ void check_dip_switches_isr(void) {
 void check_user_switches_isr(void) {
     static uint8_t config_user_last = 0;
     static uint8_t debounce_user_cnt = 0;
-    static uint8_t debounce_fire_cnt = 0;
     static bool user_inputs_initialized = false;
     const uint8_t debounce_user_done = 15;
-    // Fire tap timing is evaluated in ISR ticks (pack_isr_interval_ms = 4 ms).
-    // Keep a small minimum to reject noise, but gate fire immediately so short
-    // presses in TVG mode do not transition into firing before release.
-    const uint8_t debounce_fire_hold_block = 1; // 4 ms to suppress early fire
-    const uint8_t debounce_fire_min = 3;        // 12 ms minimum valid tap
-    const uint8_t debounce_fire_max = 100;      // 400 ms tap upper bound
 
     uint8_t config_user_maybe = gpio_get(11);
     for (int gpio = 13; gpio <= 16; gpio++) {
         config_user_maybe |= (gpio_get(gpio) << (gpio - 13 + 1));
     }
 
-    // Invert and mask to the five valid user switch bits
-    config_user_maybe = (~config_user_maybe) & USER_SWITCH_VALID_MASK;
-    if (config_user_maybe != (user_switches & USER_SWITCH_VALID_MASK)) {
+    // Invert and mask to the user switch bits debounced here. FIRE is handled
+    // by check_fire_switch_isr() below, which owns that bit.
+    config_user_maybe = (~config_user_maybe) & USER_SWITCH_DEBOUNCED_MASK;
+    if (config_user_maybe != (user_switches & USER_SWITCH_DEBOUNCED_MASK)) {
 
         if (config_user_maybe != config_user_last) {
             debounce_user_cnt = 0;
@@ -188,58 +350,15 @@ void check_user_switches_isr(void) {
                 user_switch_flags &= ~USER_SWITCH_FLAG_EDGE_EVENTS_MASK;
             }
 
-            user_switches = config_user_maybe;
+            user_switches =
+                (user_switches & USER_SWITCH_FIRE_MASK) | config_user_maybe;
             debounce_user_cnt = 0;
         }
     } else {
         debounce_user_cnt = 0;
     }
 
-    if (((config_dip_sw & DIP_PACKSEL_MASK) == DIP_PACKSEL1_MASK) ||
-        (((config_dip_sw & DIP_PACKSEL_MASK) == DIP_PACKSEL_MASK) &&
-         (config_dip_sw & DIP_HEAT_MASK))) {
-        static bool fire_stable_pressed = false;
-        static bool fire_last_sample = false;
-        static uint8_t fire_stable_cnt = 0;
-        const uint8_t fire_stable_done = 3;
-
-        bool fire_sample_pressed = (gpio_get(15) == 0);
-        if (fire_sample_pressed != fire_last_sample) {
-            fire_last_sample = fire_sample_pressed;
-            fire_stable_cnt = 0;
-        } else if (fire_stable_cnt < fire_stable_done) {
-            fire_stable_cnt++;
-        }
-
-        if ((fire_stable_cnt >= fire_stable_done) &&
-            (fire_stable_pressed != fire_sample_pressed)) {
-            fire_stable_pressed = fire_sample_pressed;
-            if (!fire_stable_pressed) {
-                if ((debounce_fire_cnt >= debounce_fire_min) &&
-                    (debounce_fire_cnt <= debounce_fire_max)) {
-                    user_switch_flags |= USER_SWITCH_FLAG_FIRE_TAP_MASK;
-                }
-                user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_HELD_MASK;
-                debounce_fire_cnt = 0;
-            } else {
-                user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_TAP_MASK;
-            }
-        }
-
-        if (fire_stable_pressed) {
-            if (debounce_fire_cnt < 250) {
-                debounce_fire_cnt++;
-            }
-            if (debounce_fire_cnt == debounce_fire_hold_block) {
-                user_switch_flags |= USER_SWITCH_FLAG_FIRE_HELD_MASK;
-            } else if (debounce_fire_cnt == debounce_fire_max) {
-                user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_MASK;
-            }
-        }
-    } else {
-        debounce_fire_cnt = 0;
-        user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_MASK;
-    }
+    check_fire_switch_isr();
 }
 
 // --- Switch state accessors ---
@@ -264,7 +383,9 @@ bool wand_standby_sw(void) { return (!pu_sw() && vent_sw()); }
 
 // --- Flag clearing functions ---
 void clear_fire_tap(void) {
-    user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_MASK;
+    // Only the tap event is cleared here. The held-off flag tracks the state
+    // of the button itself and is owned by check_fire_switch_isr().
+    user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_TAP_MASK;
 }
 void clear_song_toggle(void) {
     user_switch_flags &= ~USER_SWITCH_FLAG_SONG_TOGGLE_MASK;
@@ -304,11 +425,33 @@ PackType config_pack_type(void) {
 }
 
 /**
+ * @brief Reports whether the configured pack type cycles TVG weapon modes.
+ * @return True for the TVG and Afterlife TVG pack types.
+ */
+bool config_pack_is_tvg(void) {
+    PackType pack_type = config_pack_type();
+    return ((pack_type == PACK_TYPE_TVG_FADE) ||
+            (pack_type == PACK_TYPE_AFTER_TVG));
+}
+
+/**
  * @brief Determines the cyclotron rotation direction.
  * @note Currently hardcoded to return 0 (clockwise).
  * @return 0 for clockwise, 1 for counter-clockwise.
  */
 uint8_t config_cyclotron_dir(void) { return 0; }
+
+/**
+ * @brief Reports what the fire line detector currently believes is attached.
+ */
+FireLinkState fire_link_state(void) { return fire_link; }
+
+/**
+ * @brief Longest fire pulse currently treated as a TVG mode change request.
+ */
+uint16_t fire_tap_window_ms(void) {
+    return (uint16_t)(fire_tap_window_ticks() * PACK_ISR_INTERVAL_MS);
+}
 
 #ifdef __cplusplus
 }

--- a/SOFTWARE/klystron_IO_support.cpp
+++ b/SOFTWARE/klystron_IO_support.cpp
@@ -149,12 +149,32 @@ static const uint8_t FIRE_DEBOUNCE_SAMPLES = 2;
 /** @brief Shortest pulse accepted as a deliberate tap. */
 static const uint32_t FIRE_TAP_MIN_US = 20000;
 /**
- * @brief Pulse width separating a TVG mode change from a fire request.
- * @details The wand lights board emits a fixed 100 ms pulse for the ear
- *          button and stretches its fire button to at least 180 ms, so this
- *          sits between the two with 40 ms of margin either side.
+ * @brief Pulse width separating a TVG mode change from a fire request, in ms.
+ * @details The wand lights board emits a fixed 100 ms pulse for the ear button
+ *          and stretches its fire button to at least 180 ms, so the useful
+ *          range for this threshold is bounded by those two figures.
+ *
+ *          Sweeping the classifier across poll intervals of 4 to 6 ms and
+ *          every phase alignment of the pulse against the poll grid, a 100 ms
+ *          pulse stays a mode change for any threshold from 97 ms up, and a
+ *          180 ms pulse still fires for any threshold up to 173 ms. 135 ms is
+ *          the midpoint of that 97..173 band, so the margin is an equal 38 ms
+ *          on each side.
+ *
+ *          The debounce takes nothing out of the pulse - widths are measured
+ *          between the raw edges, so debouncing delays when an edge is
+ *          believed, not what it measures. The band is narrower than 100..180
+ *          purely because "still held" can only be noticed at a poll, which
+ *          shortens an observed width by up to one poll interval.
+ *
+ *          Overridable at build time (-DFIRE_TAP_WINDOW_MS=...) so the
+ *          threshold can be re-swept against real hardware without editing
+ *          source.
  */
-static const uint32_t FIRE_TAP_WINDOW_US = 140000;
+#ifndef FIRE_TAP_WINDOW_MS
+#define FIRE_TAP_WINDOW_MS 135
+#endif
+static const uint32_t FIRE_TAP_WINDOW_US = FIRE_TAP_WINDOW_MS * 1000u;
 
 /**
  * @brief ISR-based debounce and classification of the FIRE input.

--- a/SOFTWARE/klystron_IO_support.cpp
+++ b/SOFTWARE/klystron_IO_support.cpp
@@ -134,94 +134,27 @@ void check_dip_switches_isr(void) {
 
 // === FIRE input timing ===
 //
-// Everything below is counted in ISR ticks of PACK_ISR_INTERVAL_MS, so a
-// measured pulse width is only accurate to within one tick either way.
+// All of these are wall-clock microseconds read from the hardware timer, not
+// counts of ISR calls. The pack timer is armed with a positive delay, which
+// the SDK defines as the gap between one callback ending and the next
+// starting, and the callback also drives the LED output, so the interval
+// between two polls is the nominal 4 ms plus however long the last pass took.
+// Counting polls would make every threshold below drift with LED load;
+// timestamping the edges keeps 140 ms meaning 140 ms.
 
-/** @brief Stable samples required before a fire edge is accepted (12 ms). */
-static const uint16_t FIRE_DEBOUNCE_TICKS = PACK_ISR_TICKS(12);
-/** @brief Shortest pulse accepted as a deliberate tap (20 ms). */
-static const uint16_t FIRE_TAP_MIN_TICKS = PACK_ISR_TICKS(20);
-/** @brief Tap window when a wand lights board drives the fire line. */
-static const uint16_t FIRE_TAP_WINDOW_WAND_TICKS = PACK_ISR_TICKS(140);
-/** @brief Tap window when a plain switch drives the fire line. */
-static const uint16_t FIRE_TAP_WINDOW_STANDALONE_TICKS = PACK_ISR_TICKS(300);
-
-// --- Wand lights link detection ---
-//
-// There is no dedicated wand-present input, so the link is identified from
-// the shape of the pulses arriving on the fire line. A wand lights board
-// never passes the raw button through:
-//
-//   * a press of the wand's FIRE button is stretched to at least 180 ms
-//   * a press of the wand's EAR button emits a fixed 100 ms pulse
-//
-// So a wand can only ever produce a pulse of about 100 ms or one of 180 ms
-// and up; nothing in between, and nothing shorter. A switch wired straight to
-// the FIRE input has no such shaping and lands wherever the user's thumb puts
-// it - typically well above 140 ms, which is exactly why a 140 ms window is
-// unusable standalone.
-//
-// A completed pulse is therefore classed as:
-//
-//   76..124 ms  only the wand's ear pulse lands here -> wand attached
-//   128..164 ms a wand cannot generate this width    -> standalone
-//   otherwise   ambiguous, leaves the link state alone
-//
-// Until there is evidence either way a wand is assumed, because mistaking a
-// wand's 180 ms fire pulse for a mode change desynchronises the pack from the
-// wand, which is far worse than a standalone tap firing once before the link
-// is identified.
-
-/** @brief Pulse width range matching the wand's fixed ear pulse. */
-static const uint16_t FIRE_WAND_EAR_MIN_TICKS = PACK_ISR_TICKS(76);
-static const uint16_t FIRE_WAND_EAR_MAX_TICKS = PACK_ISR_TICKS(124);
-/** @brief Pulse width range no wand lights board can produce. */
-static const uint16_t FIRE_WAND_GAP_MIN_TICKS = PACK_ISR_TICKS(128);
-static const uint16_t FIRE_WAND_GAP_MAX_TICKS = PACK_ISR_TICKS(164);
-/** @brief Contrary pulses needed to overturn an established link state. */
-static const uint8_t FIRE_LINK_FLIP_COUNT = 2;
-
-/** @brief What is currently believed to be driving the fire line. */
-static volatile FireLinkState fire_link = FIRE_LINK_UNKNOWN;
-
+/** @brief How long a level must hold before an edge is accepted. */
+static const uint32_t FIRE_DEBOUNCE_US = 12000;
+/** @brief Polls a level must hold for, on top of FIRE_DEBOUNCE_US. */
+static const uint8_t FIRE_DEBOUNCE_SAMPLES = 2;
+/** @brief Shortest pulse accepted as a deliberate tap. */
+static const uint32_t FIRE_TAP_MIN_US = 20000;
 /**
- * @brief Feed a completed fire pulse width into the link detector.
- * @param width_ticks Measured width of the pulse in ISR ticks.
+ * @brief Pulse width separating a TVG mode change from a fire request.
+ * @details The wand lights board emits a fixed 100 ms pulse for the ear
+ *          button and stretches its fire button to at least 180 ms, so this
+ *          sits between the two with 40 ms of margin either side.
  */
-static void classify_fire_pulse(uint16_t width_ticks) {
-    static uint8_t contrary_pulses = 0;
-    FireLinkState evidence = FIRE_LINK_UNKNOWN;
-
-    if ((width_ticks >= FIRE_WAND_EAR_MIN_TICKS) &&
-        (width_ticks <= FIRE_WAND_EAR_MAX_TICKS)) {
-        evidence = FIRE_LINK_WAND;
-    } else if ((width_ticks >= FIRE_WAND_GAP_MIN_TICKS) &&
-               (width_ticks <= FIRE_WAND_GAP_MAX_TICKS)) {
-        evidence = FIRE_LINK_STANDALONE;
-    }
-
-    if (evidence == FIRE_LINK_UNKNOWN) {
-        return;
-    }
-    if (fire_link == FIRE_LINK_UNKNOWN) {
-        fire_link = evidence;
-        contrary_pulses = 0;
-    } else if (evidence == fire_link) {
-        contrary_pulses = 0;
-    } else if (++contrary_pulses >= FIRE_LINK_FLIP_COUNT) {
-        // Only overturn a settled link after repeated disagreement so a single
-        // oddly timed press cannot flip the timing out from under the user.
-        fire_link = evidence;
-        contrary_pulses = 0;
-    }
-}
-
-/** @brief Tap window currently in force, in ISR ticks. */
-static uint16_t fire_tap_window_ticks(void) {
-    return (fire_link == FIRE_LINK_STANDALONE)
-               ? FIRE_TAP_WINDOW_STANDALONE_TICKS
-               : FIRE_TAP_WINDOW_WAND_TICKS;
-}
+static const uint32_t FIRE_TAP_WINDOW_US = 140000;
 
 /**
  * @brief ISR-based debounce and classification of the FIRE input.
@@ -236,64 +169,67 @@ static uint16_t fire_tap_window_ticks(void) {
 static void check_fire_switch_isr(void) {
     static bool fire_stable_pressed = false;
     static bool fire_last_sample = false;
-    static uint16_t fire_stable_cnt = 0;
-    static uint16_t fire_press_ticks = 0;
+    static uint8_t fire_stable_samples = 0;
+    static uint32_t fire_edge_us = 0;
+    static uint32_t fire_press_us = 0;
+    static bool fire_window_expired = false;
 
     const bool tvg = config_pack_is_tvg();
-    const uint16_t tap_window = fire_tap_window_ticks();
+    const uint32_t now_us = time_us_32();
 
     bool fire_sample_pressed = (gpio_get(GPI_FIRE) == 0);
     if (fire_sample_pressed != fire_last_sample) {
         fire_last_sample = fire_sample_pressed;
-        fire_stable_cnt = 0;
-    } else if (fire_stable_cnt < FIRE_DEBOUNCE_TICKS) {
-        fire_stable_cnt++;
+        fire_stable_samples = 0;
+        // Remember when the line actually moved, not when the debounce
+        // finished, so a measured width is the width of the real pulse.
+        fire_edge_us = now_us;
+    } else if (fire_stable_samples < FIRE_DEBOUNCE_SAMPLES) {
+        fire_stable_samples++;
     }
 
-    // Count every sample the contact has been seen closed for. The counter is
-    // frozen the moment the raw input opens, so a width can never creep past
-    // the tap window while the release is still being debounced. That keeps
-    // "released inside the window" and "still held at the end of it" mutually
-    // exclusive.
+    // Latched, so a bounce part way through a long hold cannot momentarily
+    // re-arm the gate and chop the firing sound in half. It can only be set
+    // while the line is still down, which is what keeps "released inside the
+    // window" and "still held at the end of it" mutually exclusive.
     if (fire_stable_pressed && fire_sample_pressed &&
-        (fire_press_ticks < UINT16_MAX)) {
-        fire_press_ticks++;
+        ((uint32_t)(now_us - fire_press_us) > FIRE_TAP_WINDOW_US)) {
+        fire_window_expired = true;
     }
 
-    if ((fire_stable_cnt >= FIRE_DEBOUNCE_TICKS) &&
-        (fire_stable_pressed != fire_sample_pressed)) {
+    bool fire_debounced = (fire_stable_samples >= FIRE_DEBOUNCE_SAMPLES) &&
+                          ((uint32_t)(now_us - fire_edge_us) >= FIRE_DEBOUNCE_US);
+    if (fire_debounced && (fire_stable_pressed != fire_sample_pressed)) {
         fire_stable_pressed = fire_sample_pressed;
         if (fire_stable_pressed) {
-            // Account for the samples that went into accepting the press:
-            // this one plus the FIRE_DEBOUNCE_TICKS before it.
-            fire_press_ticks = FIRE_DEBOUNCE_TICKS + 1;
+            fire_press_us = fire_edge_us;
+            fire_window_expired = false;
             user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_TAP_MASK;
             user_switches |= USER_SWITCH_FIRE_MASK;
         } else {
-            if (tvg) {
-                if ((fire_press_ticks >= FIRE_TAP_MIN_TICKS) &&
-                    (fire_press_ticks <= tap_window)) {
-                    user_switch_flags |= USER_SWITCH_FLAG_FIRE_TAP_MASK;
-                }
-                // Only TVG presses are useful evidence: they are the ones made
-                // while trying to change mode. Short bursts of firing in the
-                // other pack types would just muddy the classification.
-                classify_fire_pulse(fire_press_ticks);
+            // A tap is exactly "the window never expired", the same latch the
+            // gate below reads. Deciding it from the measured width instead
+            // would leave a sliver just past the window where the line was
+            // released between two polls: too long to be a tap, never seen
+            // held long enough to be a fire, so the press did nothing at all.
+            uint32_t width_us = (uint32_t)(fire_edge_us - fire_press_us);
+            if (tvg && !fire_window_expired && (width_us >= FIRE_TAP_MIN_US)) {
+                user_switch_flags |= USER_SWITCH_FLAG_FIRE_TAP_MASK;
             }
             // Drop the press straight away. Leaving it set would let fire_sw()
             // read true for the rest of the release debounce and turn a mode
             // change into a burst of firing.
             user_switches &= ~USER_SWITCH_FIRE_MASK;
-            fire_press_ticks = 0;
+            fire_window_expired = false;
         }
     }
 
-    // Re-evaluated every tick rather than latched on an edge so that the main
+    // Re-evaluated every poll rather than latched on an edge so that the main
     // loop clearing flags, or the pack type changing mid-press, cannot leave
     // the gate stuck in the wrong position.
     if (!tvg) {
         user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_MASK;
-    } else if (fire_stable_pressed && (fire_press_ticks <= tap_window)) {
+    } else if (fire_stable_pressed && !fire_window_expired) {
         user_switch_flags |= USER_SWITCH_FLAG_FIRE_HELD_MASK;
     } else {
         user_switch_flags &= ~USER_SWITCH_FLAG_FIRE_HELD_MASK;
@@ -440,18 +376,6 @@ bool config_pack_is_tvg(void) {
  * @return 0 for clockwise, 1 for counter-clockwise.
  */
 uint8_t config_cyclotron_dir(void) { return 0; }
-
-/**
- * @brief Reports what the fire line detector currently believes is attached.
- */
-FireLinkState fire_link_state(void) { return fire_link; }
-
-/**
- * @brief Longest fire pulse currently treated as a TVG mode change request.
- */
-uint16_t fire_tap_window_ms(void) {
-    return (uint16_t)(fire_tap_window_ticks() * PACK_ISR_INTERVAL_MS);
-}
 
 #ifdef __cplusplus
 }

--- a/SOFTWARE/klystron_IO_support.h
+++ b/SOFTWARE/klystron_IO_support.h
@@ -22,9 +22,21 @@ extern "C" {
 #endif
 
 // === GPIO assignments ===
+static const uint GPI_FIRE = 15;
 static const uint GPO_NBUSY_TO_WAND = 12;
 static const uint GPO_VENT_LIGHT = 28;
 static const uint GPO_MUTE = 22;
+
+/**
+ * @brief Period of the repeating pack timer ISR, in milliseconds.
+ * @details `pack_isr_interval_ms` is defined from this macro. Switch input
+ *          timing is measured in ISR ticks, so the macro is needed wherever a
+ *          millisecond figure has to become a compile-time tick count.
+ */
+#define PACK_ISR_INTERVAL_MS 4u
+
+/** @brief Convert a millisecond duration into whole pack ISR ticks. */
+#define PACK_ISR_TICKS(ms) ((uint16_t)((ms) / PACK_ISR_INTERVAL_MS))
 
 // === DIP switch masks ===
 static const uint8_t DIP_PACKSEL0_MASK = 0x01;
@@ -44,6 +56,13 @@ static const uint8_t USER_SWITCH_PU_MASK = 0x10;
 static const uint8_t USER_SWITCH_VALID_MASK =
     (USER_SWITCH_PACK_PU_MASK | USER_SWITCH_VENT_MASK |
      USER_SWITCH_SONG_MASK | USER_SWITCH_FIRE_MASK | USER_SWITCH_PU_MASK);
+/**
+ * @brief Switches handled by the shared slow debounce.
+ * @details FIRE is deliberately excluded: it has its own fast debounce so
+ *          that firing can start as soon as the contact is stable.
+ */
+static const uint8_t USER_SWITCH_DEBOUNCED_MASK =
+    (USER_SWITCH_VALID_MASK & (uint8_t)~USER_SWITCH_FIRE_MASK);
 
 // === User switch event/flag masks ===
 static const uint8_t USER_SWITCH_FLAG_FIRE_HELD_MASK = 0x01;
@@ -63,6 +82,22 @@ typedef enum {
     PACK_TYPE_AFTERLIFE,
     PACK_TYPE_AFTER_TVG
 } PackType;
+
+/**
+ * @brief What is driving the FIRE input.
+ * @details A wand lights board shapes the fire line before it reaches this
+ *          board, so the tap window that separates a mode change from a fire
+ *          request depends on whether one is attached. See
+ *          `klystron_IO_support.cpp` for how the link is detected.
+ */
+typedef enum {
+    /** Not enough evidence yet; wand timing is assumed. */
+    FIRE_LINK_UNKNOWN = 0,
+    /** A wand lights board is shaping the fire line. */
+    FIRE_LINK_WAND,
+    /** The fire line comes straight from a switch (standalone use). */
+    FIRE_LINK_STANDALONE
+} FireLinkState;
 
 // === Global I/O state variables ===
 extern volatile uint16_t adj_pot[2];
@@ -102,7 +137,12 @@ void unmute_audio(void);
 
 // --- Configuration accessors ---
 PackType config_pack_type(void);
+bool config_pack_is_tvg(void);
 uint8_t config_cyclotron_dir(void);
+
+// --- Fire input timing ---
+FireLinkState fire_link_state(void);
+uint16_t fire_tap_window_ms(void);
 
 #ifdef __cplusplus
 }

--- a/SOFTWARE/klystron_IO_support.h
+++ b/SOFTWARE/klystron_IO_support.h
@@ -27,17 +27,6 @@ static const uint GPO_NBUSY_TO_WAND = 12;
 static const uint GPO_VENT_LIGHT = 28;
 static const uint GPO_MUTE = 22;
 
-/**
- * @brief Period of the repeating pack timer ISR, in milliseconds.
- * @details `pack_isr_interval_ms` is defined from this macro. Switch input
- *          timing is measured in ISR ticks, so the macro is needed wherever a
- *          millisecond figure has to become a compile-time tick count.
- */
-#define PACK_ISR_INTERVAL_MS 4u
-
-/** @brief Convert a millisecond duration into whole pack ISR ticks. */
-#define PACK_ISR_TICKS(ms) ((uint16_t)((ms) / PACK_ISR_INTERVAL_MS))
-
 // === DIP switch masks ===
 static const uint8_t DIP_PACKSEL0_MASK = 0x01;
 static const uint8_t DIP_PACKSEL1_MASK = 0x02;
@@ -83,22 +72,6 @@ typedef enum {
     PACK_TYPE_AFTER_TVG
 } PackType;
 
-/**
- * @brief What is driving the FIRE input.
- * @details A wand lights board shapes the fire line before it reaches this
- *          board, so the tap window that separates a mode change from a fire
- *          request depends on whether one is attached. See
- *          `klystron_IO_support.cpp` for how the link is detected.
- */
-typedef enum {
-    /** Not enough evidence yet; wand timing is assumed. */
-    FIRE_LINK_UNKNOWN = 0,
-    /** A wand lights board is shaping the fire line. */
-    FIRE_LINK_WAND,
-    /** The fire line comes straight from a switch (standalone use). */
-    FIRE_LINK_STANDALONE
-} FireLinkState;
-
 // === Global I/O state variables ===
 extern volatile uint16_t adj_pot[2];
 extern volatile uint8_t config_dip_sw;
@@ -139,10 +112,6 @@ void unmute_audio(void);
 PackType config_pack_type(void);
 bool config_pack_is_tvg(void);
 uint8_t config_cyclotron_dir(void);
-
-// --- Fire input timing ---
-FireLinkState fire_link_state(void);
-uint16_t fire_tap_window_ms(void);
 
 #ifdef __cplusplus
 }

--- a/SOFTWARE/monitors.cpp
+++ b/SOFTWARE/monitors.cpp
@@ -436,8 +436,7 @@ void mode_monitor(void) {
   if (!fire_tap()) {
     return;
   }
-  if ((config_pack_type() == PACK_TYPE_TVG_FADE) ||
-      (config_pack_type() == PACK_TYPE_AFTER_TVG)) {
+  if (config_pack_is_tvg()) {
     PackMode prev = pack_state_get_mode();
     PackMode next = (PackMode)((int)prev + 1);
     switch (prev) {

--- a/SOFTWARE/monitors.cpp
+++ b/SOFTWARE/monitors.cpp
@@ -105,6 +105,7 @@ void song_monitor(void) {
         party_mode_set_animation(
             (party_animation_t)(party_animation_index - 1));
       }
+      // Consumed here, so mode_monitor() must not see it as well.
       if (tap_now) {
         clear_fire_tap();
       }
@@ -123,9 +124,12 @@ void song_monitor(void) {
     break;
   }
 
-  if (tap_now) {
-    clear_fire_tap();
-  }
+  // Deliberately no blanket clear_fire_tap() here. This monitor runs at the
+  // top of every pass through the state machine, so swallowing every tap
+  // would leave mode_monitor() nothing to act on and TVG weapon cycling would
+  // only work when the release happened to land between the two calls. Party
+  // mode above clears the taps it actually uses; everything else belongs to
+  // whichever state is running.
   last_fire_state = fire_now;
 }
 
@@ -430,10 +434,13 @@ void mode_change_major(uint8_t cyclotron_pattern_base, uint8_t first_sound,
  * @brief Monitor fire taps to cycle through available pack modes for TVG.
  */
 void mode_monitor(void) {
-  if (song_is_playing()) {
+  if (!fire_tap()) {
     return;
   }
-  if (!fire_tap()) {
+  if (song_is_playing()) {
+    // Modes do not cycle during a song. Drop the tap rather than leaving it
+    // pending, or it would change mode the moment the song ends.
+    clear_fire_tap();
     return;
   }
   if (config_pack_is_tvg()) {

--- a/SOFTWARE/pack_config.cpp
+++ b/SOFTWARE/pack_config.cpp
@@ -120,4 +120,4 @@ const uint32_t pack_sound_baud_rate = 9600;
 const uint8_t pack_sound_max_volume = 30;
 
 /** @brief Repeating timer interval in milliseconds. */
-const uint32_t pack_isr_interval_ms = 4;
+const uint32_t pack_isr_interval_ms = PACK_ISR_INTERVAL_MS;

--- a/SOFTWARE/pack_config.cpp
+++ b/SOFTWARE/pack_config.cpp
@@ -120,4 +120,4 @@ const uint32_t pack_sound_baud_rate = 9600;
 const uint8_t pack_sound_max_volume = 30;
 
 /** @brief Repeating timer interval in milliseconds. */
-const uint32_t pack_isr_interval_ms = PACK_ISR_INTERVAL_MS;
+const uint32_t pack_isr_interval_ms = 4;

--- a/SOFTWARE/pack_state.cpp
+++ b/SOFTWARE/pack_state.cpp
@@ -62,10 +62,8 @@ void cy_speed_ramp_update(void) {
 }
 
 void pack_state_init(void) {
-    pack_ctx.mode = ((config_pack_type() == PACK_TYPE_TVG_FADE) ||
-                     (config_pack_type() == PACK_TYPE_AFTER_TVG))
-                        ? pack_ctx.startup_mode
-                        : PACK_MODE_PROTON_STREAM;
+    pack_ctx.mode = config_pack_is_tvg() ? pack_ctx.startup_mode
+                                         : PACK_MODE_PROTON_STREAM;
     pack_ctx.state = PS_OFF;
     update_pack_colors();
     clear_fire_tap();
@@ -232,8 +230,7 @@ void pack_state_process(void) {
             }
         } else if (!song_is_playing() && fire_sw()) {
             PackMode mode = pack_state_get_mode();
-            PackState next = (((config_pack_type() == PACK_TYPE_TVG_FADE) ||
-                               (config_pack_type() == PACK_TYPE_AFTER_TVG)) &&
+            PackState next = (config_pack_is_tvg() &&
                               (mode == PACK_MODE_SLIME_BLOWER ||
                                mode == PACK_MODE_SLIME_TETHER))
                                  ? PS_SLIME_FIRE


### PR DESCRIPTION
## Summary
This PR refactors the fire input handling to use hardware microsecond timing instead of ISR tick counting, enabling precise 140 ms tap window detection for TVG mode weapon cycling. The fire switch now has its own dedicated debounce logic separate from other user switches.

## Key Changes

- **New `check_fire_switch_isr()` function**: Implements hardware timer-based debounce and classification of the FIRE input with microsecond precision. Handles the ambiguous press detection in TVG modes where a pulse ending within 140 ms triggers a mode change, while a pulse still active at 140 ms triggers firing.

- **Separated fire debounce from general user switches**: Extracted fire button logic from `check_user_switches_isr()` into its own ISR function. Fire now uses fast debounce (~12 ms) while other switches use the slower shared debounce (60 ms).

- **Hardware timer-based timing**: Replaced ISR tick counting with `time_us_32()` calls to measure actual pulse widths. This makes the 140 ms threshold immune to LED load variations, since the ISR interval varies with animation complexity.

- **New `config_pack_is_tvg()` helper**: Extracted TVG pack type detection into a reusable function, replacing inline checks throughout the codebase.

- **Updated switch flag handling**: Introduced `USER_SWITCH_DEBOUNCED_MASK` to distinguish switches handled by the shared slow debounce from the fire switch. The `clear_fire_tap()` function now only clears the tap event flag, leaving the held state to be managed by the ISR.

- **Documentation**: Added comprehensive comments explaining the fire timing logic, hardware timer usage, and the 140 ms window rationale (100 ms ear button + 40 ms margin vs. 180 ms fire button).

## Notable Implementation Details

- Fire edge timestamps are captured when the line physically moves, not when debounce completes, ensuring measured widths reflect actual pulse widths.
- The `fire_window_expired` latch prevents bounces mid-hold from re-arming the gate and chopping firing sounds.
- Fire state is re-evaluated every poll rather than latched on edges, allowing pack type changes mid-press to be handled correctly.
- Version bumped to 1.1.3.